### PR TITLE
Fixed strcpy Code Example on pg. 37

### DIFF
--- a/Modern C Quick Syntax Reference - Source Code.txt
+++ b/Modern C Quick Syntax Reference - Source Code.txt
@@ -304,7 +304,7 @@ int main(void) {
   strcat(s1, s2); /* s1 = "HelloWorld" */
 
   /* Copy s1 into s2 */
-  strcpy(s2, s1); /* s2 = "HelloWorld" */
+  strcpy(s2, s1); /* s2 = "Hello" */
 
   /* Compare s1 and s2 */
   result = strcmp(s1, s2); /* 0 (equal) */

--- a/errata.md
+++ b/errata.md
@@ -1,8 +1,13 @@
 # Errata for *Book Title*
 
-On **page xx** [Summary of error]:
+On **page 37** [strcpy]:
  
-Details of error here. Highlight key pieces in **bold**.
+The code example for `strcpy` should show the result of the copy as `"Hello"` instead of `"HelloWorld"`.
+
+```
+/* Copy s1 into s2 */
+strcpy(s2, s1); /* s2 = "Hello" */
+```
 
 ***
 


### PR DESCRIPTION
# Overview

On page 37, the code example shows the incorrect result for `strcpy`.

```c
    /* Append s2 to s1 */
    strcat(s1, s2); /* s1 = "HelloWorld" */
    /* s1 should equal "Hello" here instead. */
}
```

This PR adds a correction to the code example file and `errata.md`.